### PR TITLE
Adding lmfit and dependencies for future versions of lmfit

### DIFF
--- a/python-asteval.spec
+++ b/python-asteval.spec
@@ -1,0 +1,58 @@
+%global srcname asteval
+%global summary minimalistic evaluator of python expression using ast module
+%define release 1
+
+Summary: %{summary}
+Name: python-%{srcname}
+Version: 0.9.17
+Release: %{release}%{?dist}
+Source0: https://github.com/newville/asteval/archive/0.9.17.tar.gz
+License: MIT
+Group: Science/Research
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+Prefix: %{_prefix}
+BuildArch: noarch
+Vendor: Matt Newville
+Url: https://github.com/newville/asteval/
+
+%description
+ASTEVAL provides a numpy-aware, safe(ish) ‘eval’ function
+
+Emphasis is on mathematical expressions, and so numpy ufuncs are used if available. Symbols are held in the Interpreter symbol table ‘symtable’: a simple dictionary supporting a simple, flat namespace.
+
+Expressions can be compiled into ast node for later evaluation, using the values in the symbol table current at evaluation time.
+
+%package -n python%{python3_pkgversion}-%{srcname}
+Summary:  %{summary}
+Requires: python%{python3_pkgversion}
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+BuildRequires: python3-setuptools
+
+%description -n python%{python3_pkgversion}-%{srcname}
+ASTEVAL provides a numpy-aware, safe(ish) ‘eval’ function
+
+Emphasis is on mathematical expressions, and so numpy ufuncs are used if available. Symbols are held in the Interpreter symbol table ‘symtable’: a simple dictionary supporting a simple, flat namespace.
+
+Expressions can be compiled into ast node for later evaluation, using the values in the symbol table current at evaluation time.
+
+%prep
+%setup -n %{srcname}-%{version} -n %{srcname}-%{version}
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+# testing isn't registered correctly with setup.py
+#check
+#{__python3} setup.py test
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -n python%{python3_pkgversion}-%{srcname}
+%doc README.rst
+%license LICENSE
+%{python3_sitelib}/*

--- a/python-lmfit.spec
+++ b/python-lmfit.spec
@@ -1,0 +1,57 @@
+%global srcname lmfit-py
+%global summary Non-Linear Least Squares Minimization
+%global descr Non-Linear Least Squares Minimization, with flexible Parameter settings, based on scipy.optimize.leastsq, and with many additional classes and methods for curve fitting http:/lmfit.github.io/lmfit-py/
+%define release 1
+
+Summary: %{summary}
+Name: python-%{srcname}
+Version: 0.8.3
+Release: %{release}%{?dist}
+Source0: https://github.com/lmfit/lmfit-py/archive/%{version}.tar.gz
+License: Custom
+Group: Science/Research
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+Prefix: %{_prefix}
+BuildArch: noarch
+Vendor: Matt Newville
+Url: https://lmfit.github.io/lmfit-py/
+
+%description
+%{descr}
+
+%package -n python%{python3_pkgversion}-%{srcname}
+Summary:  %{summary}
+Requires: python%{python3_pkgversion}
+Requires: python%{python3_pkgversion}-numpy >= 1.5
+Requires: python%{python3_pkgversion}-scipy >= 0.13
+Requires: python%{python3_pkgversion}-pandas
+Requires: python%{python3_pkgversion}-matplotlib
+Requires: python%{python3_pkgversion}-dateutil
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+BuildRequires: python3-setuptools
+BuildRequires: python%{python3_pkgversion}-nose
+
+%description -n python%{python3_pkgversion}-%{srcname}
+%{descr}
+
+%prep
+%setup -n %{srcname}-%{version} -n %{srcname}-%{version}
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+# testing is somehow broken, but the package did work
+#check
+#__python3} setup.py test
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -n python%{python3_pkgversion}-%{srcname}
+%doc README.rst
+%license LICENSE
+%{python3_sitelib}/*

--- a/python-uncertainties.spec
+++ b/python-uncertainties.spec
@@ -1,0 +1,79 @@
+%global srcname uncertainties
+%global summary Transparent calculations with uncertainties on the quantities involved (aka error propagation); fast calculation of derivatives
+%define release 1
+
+Summary: %{summary}
+Name: python-%{srcname}
+Version: 3.1.2
+Release: %{release}%{?dist}
+#Source0: https://github.com/lebigot/uncertainties/archive/3.1.2.tar.gz
+Source0: https://files.pythonhosted.org/packages/2a/c2/babbe5b16141859dd799ed31c03987100a7b6d0ca7c0ed4429c96ce60fdf/uncertainties-3.1.2.tar.gz
+License: MIT
+Group: Science/Research
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+Prefix: %{_prefix}
+BuildArch: noarch
+Vendor: Eric Lebigot
+Url: https://uncertainties-python-package.readthedocs.io/en/latest/
+
+%description
+uncertainties allows calculations such as (2 +/- 0.1)*2 = 4 +/- 0.2 to be performed transparently. Much more complex mathematical expressions involving numbers with uncertainties can also be evaluated directly.
+
+The uncertainties package takes the pain and complexity out of uncertainty calculations.
+
+%package -n python2-%{srcname}
+Summary:  %{summary}
+Requires: python
+Requires: python2-numpy
+%{?python_provide:%python_provide python2-%{srcname}}
+
+BuildRequires: python-setuptools
+
+%description -n python2-%{srcname}
+uncertainties allows calculations such as (2 +/- 0.1)*2 = 4 +/- 0.2 to be performed transparently. Much more complex mathematical expressions involving numbers with uncertainties can also be evaluated directly.
+
+The uncertainties package takes the pain and complexity out of uncertainty calculations.
+
+%package -n python%{python3_pkgversion}-%{srcname}
+Summary:  %{summary}
+Requires: python%{python3_pkgversion}
+Requires: python%{python3_pkgversion}-numpy
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+BuildRequires: python3-setuptools
+BuildRequires: python3-devel
+
+%description -n python%{python3_pkgversion}-%{srcname}
+uncertainties allows calculations such as (2 +/- 0.1)*2 = 4 +/- 0.2 to be performed transparently. Much more complex mathematical expressions involving numbers with uncertainties can also be evaluated directly.
+
+The uncertainties package takes the pain and complexity out of uncertainty calculations.
+
+%prep
+%setup -n %{srcname}-%{version} -n %{srcname}-%{version}
+
+# build doesn't work because install translates from 2to3
+%build
+2to3-3 -w uncertainties-py27/*.py
+2to3-3 -w uncertainties-py27//lib1to2/*.py
+2to3-3 -w uncertainties-py27/unumpy/*.py
+%py2_build
+%py3_build
+
+%install
+%py2_install
+%py3_install
+
+# testing is somehow broken, but the package did work
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -n python2-%{srcname}
+%doc README.rst
+%license LICENSE.txt
+%{python2_sitelib}/*
+
+%files -n python%{python3_pkgversion}-%{srcname}
+%doc README.rst
+%license LICENSE.txt
+%{python3_sitelib}/*


### PR DESCRIPTION
Unfortunately, the versions of numpy/scipy in epel-7 are too old to use a newer version of lmfit. I did not realize that while putting together packages for [uncertainties](https://uncertainties-python-package.readthedocs.io/en/latest/) and [asteval](https://github.com/newville/asteval/).